### PR TITLE
Simplify math in Monee function

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,11 +74,11 @@ class MoneeClock extends Component {
 }
 
 
-function Seconds(start,newt) {
+function Seconds(start, newt) {
     return (newt - start)/ 1000;
 }
 function Moneee(seconds, moneypersec) {
-    return Math.round(seconds * moneypersec * 100) / 100;
+    return Math.round(seconds * moneypersec);
 }
 
 export default MainSection;


### PR DESCRIPTION
The `100`s used in the Monee function will cancel out regardless of the values of `seconds` and `moneypersec`, so there's no point in keeping them.